### PR TITLE
SM: Update chart after collapsing or expanding entries in the tree

### DIFF
--- a/timeline-chart/src/layer/time-graph-chart.ts
+++ b/timeline-chart/src/layer/time-graph-chart.ts
@@ -36,6 +36,7 @@ export class TimeGraphChart extends TimeGraphChartLayer {
     protected providedResolution: number;
 
     protected fetching: boolean;
+    protected allowToUpdateChart: boolean;
 
     protected shiftKeyDown: boolean;
     protected ctrlKeyDown: boolean;
@@ -46,6 +47,7 @@ export class TimeGraphChart extends TimeGraphChartLayer {
         super(id, rowController);
         this.providedRange = { start: 0, end: 0 };
         this.providedResolution = 1;
+        this.allowToUpdateChart = false;
     }
 
     protected afterAddToContainer() {
@@ -139,13 +141,19 @@ export class TimeGraphChart extends TimeGraphChartLayer {
         this.updateScaleAndPosition();
     }
 
+    updateChart() {
+        this.allowToUpdateChart = true;
+        this.maybeFetchNewData();
+    }
+
     protected async maybeFetchNewData() {
         const resolution = this.unitController.viewRangeLength / this.stateController.canvasDisplayWidth;
         const viewRange = this.unitController.viewRange;
         if (viewRange && (
             viewRange.start < this.providedRange.start ||
             viewRange.end > this.providedRange.end ||
-            resolution < this.providedResolution
+            resolution < this.providedResolution ||
+            this.allowToUpdateChart
         )) {
             this.fetching = true;
             const rowData = await this.providers.dataProvider(viewRange, resolution);


### PR DESCRIPTION
Added a new condition in time-graph-chart.ts that allows to fetch new
data when collapsing or expanding entries. The function updateChart()
allows to update the chart's rows simulteanously when it is called
in the timegraph-output-component.ts in theia-trace-extension.

Signed-off-by: Soukaina Moussaoui <soukaina.moussaoui@polymtl.ca>