### PR TITLE
Fetch time graph chart information for the selected row.

### DIFF
--- a/timeline-chart/src/layer/time-graph-chart.ts
+++ b/timeline-chart/src/layer/time-graph-chart.ts
@@ -326,6 +326,20 @@ export class TimeGraphChart extends TimeGraphChartLayer {
         });
         return element as TimeGraphRowElement;
     }
+    
+    getRowVerticalOffset(row: TimelineChart.TimeGraphRowModel): number {
+        const rowComponent: TimeGraphRow | undefined = this.rowComponents.get(row);
+        return (rowComponent ? rowComponent.position.y : 0)
+    }
+
+    getRowHeight(row: TimelineChart.TimeGraphRowModel): number {
+        const rowComponent: TimeGraphRow | undefined = this.rowComponents.get(row);
+        return (rowComponent ? rowComponent.height : 0);
+    }
+
+    getPosition(): PIXI.ObservablePoint {
+        return this.layer.position;
+    }
 
     selectRow(row: TimelineChart.TimeGraphRowModel) {
         if (this.rowController.selectedRow) {


### PR DESCRIPTION
Added getPosition, getRowVerticalOffset and getRowHeight functions to get row specific information which is utilized by time-graph-output-component.tsx in theia-trace-extension.

This is a dependency PR for the selection of chart components on click of a row in events-table.
