### PR TITLE
States not visible in the initial zoom level

### DIFF
--- a/timeline-chart/src/components/time-graph-row-element.ts
+++ b/timeline-chart/src/components/time-graph-row-element.ts
@@ -34,7 +34,8 @@ export class TimeGraphRowElement extends TimeGraphComponent {
             x: this.range.start,
             y: this._row.position.y + ((this.row.height - this.height) / 2)
         };
-        const width = this.range.end - this.range.start;
+        // min width of a state should never be less than 1(for visibility)
+        const width = Math.max(1, this.range.end - this.range.start);
         this._options = {
             color: _style.color,
             height: this.height,

--- a/timeline-chart/src/components/time-graph-row-element.ts
+++ b/timeline-chart/src/components/time-graph-row-element.ts
@@ -34,7 +34,7 @@ export class TimeGraphRowElement extends TimeGraphComponent {
             x: this.range.start,
             y: this._row.position.y + ((this.row.height - this.height) / 2)
         };
-        // min width of a state should never be less than 1(for visibility)
+        // min width of a state should never be less than 1 (for visibility)
         const width = Math.max(1, this.range.end - this.range.start);
         this._options = {
             color: _style.color,

--- a/timeline-chart/src/layer/time-graph-chart.ts
+++ b/timeline-chart/src/layer/time-graph-chart.ts
@@ -263,7 +263,8 @@ export class TimeGraphChart extends TimeGraphChartLayer {
                                 x: this.getPixels(start - this.unitController.viewRange.start),
                                 y: el.position.y
                             },
-                            width: this.getPixels(end - start)
+                            // min width of a state should never be less than (for visibility)
+                            width: Math.max(1, this.getPixels(end - start))
                         }
                         el.update(opts);
                     }

--- a/timeline-chart/src/layer/time-graph-chart.ts
+++ b/timeline-chart/src/layer/time-graph-chart.ts
@@ -263,7 +263,7 @@ export class TimeGraphChart extends TimeGraphChartLayer {
                                 x: this.getPixels(start - this.unitController.viewRange.start),
                                 y: el.position.y
                             },
-                            // min width of a state should never be less than (for visibility)
+                            // min width of a state should never be less than 1 (for visibility)
                             width: Math.max(1, this.getPixels(end - start))
                         }
                         el.update(opts);


### PR DESCRIPTION
Set the minimum width of a state to 1 so that small states with negligible widths are visible in the initial zoom level

Signed-off-by: Satish Muddana <satish.muddana@ericsson.com>