### PR TITLE
Handle onClick event on timegraph row

### DIFF
--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -136,7 +136,8 @@ const timeGraphChart = new TimeGraphChart('timeGraphChart', {
     rowStyleProvider: (row: TimelineChart.TimeGraphRowModel) => {
         return {
             backgroundColor: 0xe0ddcf,
-            backgroundOpacity: row.selected ? 0.6 : 0,
+            // PIXI 5 doesn't handle events on elements with opacity 0. As a workaround set it to 0.001
+            backgroundOpacity: row.selected ? 0.6 : 0.001,
             lineColor: row.data && row.data.hasStates ? 0xdddddd : 0xaa4444,
             lineThickness: row.data && row.data.hasStates ? 1 : 3
         }

--- a/timeline-chart/src/components/time-graph-row.ts
+++ b/timeline-chart/src/components/time-graph-row.ts
@@ -19,7 +19,8 @@ export class TimeGraphRow extends TimeGraphComponent implements TimeGraphParentC
         protected _options: TimeGraphStyledRect,
         protected _rowIndex: number,
         public readonly model: TimelineChart.TimeGraphRowModel,
-        protected _style: TimeGraphRowStyle = { lineOpacity: 0.5, lineThickness: 1, backgroundOpacity: 0 }) {
+        // PIXI 5 doesn't handle events on elements with opacity 0. As a workaround set it to 0.001
+        protected _style: TimeGraphRowStyle = { lineOpacity: 0.5, lineThickness: 1, backgroundOpacity: 0.001 }) {
         super(id);
     }
 


### PR DESCRIPTION
This feature was woking fine with earlier versions of PIXI
Current PIXI is not able to handle events for elements with opacity 0.
Changed the Opacity as a workaround fix.

Fixes #52 

Signed-off-by: muddana-satish <satish.muddana@ericsson.com>