### PR TITLE
Destroy arrows when updating them

### DIFF
--- a/timeline-chart/src/components/time-graph-arrow.ts
+++ b/timeline-chart/src/components/time-graph-arrow.ts
@@ -17,6 +17,11 @@ export class TimeGraphArrowComponent extends TimeGraphComponent {
         this.head = new PIXI.Graphics();
     }
 
+    destroy() {
+        this.head.destroy();
+        super.destroy();
+    }
+
     render(): void {
         const { start, end } = this._options as TimeGraphArrowCoordinates;
         this._displayObject.lineStyle(1, 0x000000);

--- a/timeline-chart/src/components/time-graph-component.ts
+++ b/timeline-chart/src/components/time-graph-component.ts
@@ -59,6 +59,10 @@ export abstract class TimeGraphComponent {
         this._displayObject.clear();
     }
 
+    destroy() {
+        this._displayObject.destroy();
+    }
+
     update(opts?: TimeGraphComponentOptions) {
         if (opts) {
             this._options = opts;

--- a/timeline-chart/src/layer/time-graph-chart-arrows.ts
+++ b/timeline-chart/src/layer/time-graph-chart-arrows.ts
@@ -39,6 +39,9 @@ export class TimeGraphChartArrows extends TimeGraphChartLayer {
         if (!this.stateController) {
             throw ('Add this TimeGraphChartArrows to a container before adding arrows.');
         }
+        if (this.arrows) {
+            this.arrows.forEach(rowEl => rowEl.destroy());
+        }
         this.arrows = new Map();
         arrows.forEach(arrow => {
             this.addArrow(arrow);

--- a/timeline-chart/src/layer/time-graph-layer.ts
+++ b/timeline-chart/src/layer/time-graph-layer.ts
@@ -47,14 +47,14 @@ export abstract class TimeGraphLayer {
     }
 
     protected removeChildren() {
-        this.children.forEach(child => this.layer.removeChild(child.displayObject));
+        this.children.forEach(child => child.destroy());
         this.children = [];
     }
 
     protected removeChild(child: TimeGraphComponent) {
+        child.destroy();
         const idx = this.children.findIndex(c => c === child);
         idx && this.children.splice(idx, 1);
-        this.layer.removeChild(child.displayObject);
     }
 
     protected getPixels(ticks: number) {


### PR DESCRIPTION
Arrows are destroyed when the map is updated to not show them and cleanup gpu memory.

Signed-off-by: Arnaud Fiorini <fiorini.arnaud@gmail.com>