### PR TITLE
Support horizontal zooming selection with right mouse button

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -39,6 +39,7 @@ A reusable time axis component, that can be used independently of the other comp
 * WASD or IJKL keystrokes are available for zooming and navigation. The zooming is centered on the mouse cursor position.
 * Horizontal zooming can be performed using Ctrl+mouse wheel. The zooming is centered on the mouse cursor position.
 * Horizontal panning can be performed using the middle mouse button or Ctrl+left mouse button.
+* Horizontal zooming selection can be performed using the right mouse button.
 * The view is connected to a time controller instance and synchronizes its viewport, zoom level cursors bi-directionally.
 
 ## Data Model


### PR DESCRIPTION
Allow zooming selection with the mouse with right button drag. Change
the cursor to 'col-resize' while zooming selection is ongoing.

Restore the cursor to 'default' when zooming selection is ended by
releasing the right mouse button.

Add a zooming selection transparent overlay while zoom selection is
ongoing. Update the overlay when the view range is changed externally.

Prevent the context menu popup on right mouse click on time graph.

Ensure right mouse button mouse up outside of time graph canvas is
properly detected and handled.

Signed-off-by: Patrick Tasse <patrick.tasse@ericsson.com>