### PR TITLE
Zooming selection

### DIFF
--- a/timeline-chart/src/time-graph-unit-controller.ts
+++ b/timeline-chart/src/time-graph-unit-controller.ts
@@ -33,7 +33,7 @@ export class TimeGraphUnitController {
         this.viewRangeChangedHandlers.push(handler);
     }
 
-    onSelectionRangeChange(handler: (selectionRange: TimelineChart.TimeGraphRange) => void) {
+    onSelectionRangeChange(handler: (selectionRange?: TimelineChart.TimeGraphRange) => void) {
         this.selectionRangeChangedHandlers.push(handler);
     }
 


### PR DESCRIPTION
A part of https://github.com/theia-ide/theia-trace-extension/issues/330 
Adds the capability of zooming using the right click & drag.
For now, the zooming action deletes the selection range. It could also work by having an additional selection zone like in Trace Compass. I'm open for extra comments.
![output](https://user-images.githubusercontent.com/8209717/116323091-4f708900-a78b-11eb-95b1-02ed41d3deba.gif)
