### PR TITLE
Fix TypeError exception in TimeGraphChart

### DIFF
--- a/timeline-chart/src/layer/time-graph-chart.ts
+++ b/timeline-chart/src/layer/time-graph-chart.ts
@@ -347,6 +347,7 @@ export class TimeGraphChart extends TimeGraphChartLayer {
                         this.selectStateInNavigation();
                     }
                     if (this.mouseZooming) {
+                        delete this.zoomingSelection;
                         this.updateZoomingSelection();
                     }
                 }


### PR DESCRIPTION
When TimeGraphChart.maybeFetchNewData() was called while right-mouse
zooming was in progress (for example by navigating with WASD or
Ctrl+mouseWheel), the zoomingSelection rectangle was removed, then
updateZoomingSelection() would try to remove it again before re-creating
a new one, leading to an exception. Clear the zoomingSelection variable
before calling the method since the call to removeChildren() has already
removed it.

Signed-off-by: Patrick Tasse <patrick.tasse@ericsson.com>