### PR TITLE
Fix zooming selection height

### DIFF
--- a/timeline-chart/src/layer/time-graph-chart.ts
+++ b/timeline-chart/src/layer/time-graph-chart.ts
@@ -335,7 +335,7 @@ export class TimeGraphChart extends TimeGraphChartLayer {
                     x: mouseStartX,
                     y: 0
                 },
-                height: this.layer.height,
+                height: this.stateController.canvasDisplayHeight,
                 width: this.mouseEndX - mouseStartX
             });
             this.addChild(this.zoomingSelection);


### PR DESCRIPTION
Use the canvas height instead of layer height.

Signed-off-by: Patrick Tasse <patrick.tasse@gmail.com>