### PR TITLE
Fix mouse zooming when mouse released outside time graph

### DIFF
--- a/timeline-chart/src/layer/time-graph-chart.ts
+++ b/timeline-chart/src/layer/time-graph-chart.ts
@@ -275,7 +275,6 @@ export class TimeGraphChart extends TimeGraphChartLayer {
             this.mouseButtons = e.buttons;
             if (e.button === this.mouseDownButton && this.mouseZooming) {
                 this.mouseZooming = false;
-                this.mouseEndX = e.offsetX;
                 const start = this.mouseZoomingStart;
                 const end = this.unitController.viewRange.start + (this.mouseEndX / this.stateController.zoomFactor);
                 if (start !== end && this.unitController.viewRangeLength > 1) {


### PR DESCRIPTION
The x-coordinate of the mouseUp event is in the coordinates of the
element under the cursor at the time, which is not necessarily the time
graph coordinates.

Since the mouseEndX variable is updated (correctly) while the mouse is
being moved, just rely on that, and do not update it at mouseUp.

Signed-off-by: Patrick Tasse <patrick.tasse@ericsson.com>