### PR TITLE
Center x-axis labels

### DIFF
--- a/timeline-chart/src/components/time-graph-axis-scale.ts
+++ b/timeline-chart/src/components/time-graph-axis-scale.ts
@@ -107,7 +107,7 @@ export class TimeGraphAxisScale extends TimeGraphComponent<null> {
                                 fontSize: 10,
                                 fill: lineColor
                             });
-                            text.x = position.x + 5;
+                            text.x = position.x - (text.width / 2);
                             text.y = position.y + lineStyle(label).lineHeight;
                             this.labels.push(text);
                             this._displayObject.addChild(text);


### PR DESCRIPTION
Currently the labels of the x-axis are aligned to the left, 5 pixels after their corresponding tick in the axis.

This commit centers the labels according to their ticks. The position of the text is calculated by using the position of the tick, minus half the width of the text.

Before the change:
<img width="1023" alt="Screenshot 2021-08-12 at 16 39 47" src="https://user-images.githubusercontent.com/88502808/129266590-cefd7b99-b063-4841-8616-46ed3018651a.png">

After the change:
<img width="1030" alt="Screenshot 2021-08-12 at 16 34 44" src="https://user-images.githubusercontent.com/88502808/129266367-e70e6027-b442-444a-a156-4978d23eed08.png">

After the change in theia-trace-extension:
![Center x-axis label](https://user-images.githubusercontent.com/88502808/129373175-c556a5bf-883f-450d-af5d-6e0eadf60c5f.png)

Fixes [issue 440 in theia-ide/theia-trace-extension](https://github.com/theia-ide/theia-trace-extension/issues/440).

Signed-off-by: Rodrigo Pinto <rodrigo.pinto@calian.ca>