### PR TITLE
Use BigInt for timestamps

### DIFF
--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -36,18 +36,22 @@ container.style.width = styleConfig.mainWidth + "px";
 const testDataProvider = new TestDataProvider(styleConfig.mainWidth);
 let timeGraph = testDataProvider.getData({});
 const unitController = new TimeGraphUnitController(timeGraph.totalLength);
-unitController.numberTranslator = (theNumber: number) => {
-    const milli = Math.floor(theNumber / 1000000);
-    const micro = Math.floor((theNumber % 1000000) / 1000);
-    const nano = Math.floor((theNumber % 1000000) % 1000);
-    return milli + ':' + micro + ':' + nano;
+unitController.numberTranslator = (theNumber: bigint) => {
+    let num = theNumber.toString();
+    if (num.length > 6) {
+        num = num.slice(0, -6) + ':' + num.slice(-6);
+    }
+    if (num.length > 3) {
+        num = num.slice(0, -3) + ':' + num.slice(-3);
+    }
+    return num;
 };
 
 const providers = {
     dataProvider: (range: TimelineChart.TimeGraphRange, resolution: number) => {
         const length = range.end - range.start;
-        const overlap = ((length * 20) - length) / 2;
-        const start = range.start - overlap > 0 ? range.start - overlap : 0;
+        const overlap = length * BigInt(10);
+        const start = range.start - overlap > BigInt(0) ? range.start - overlap : BigInt(0);
         const end = range.end + overlap < unitController.absoluteRange ? range.end + overlap : unitController.absoluteRange;
         const newRange: TimelineChart.TimeGraphRange = { start, end };
         const newResolution: number = resolution * 0.1;
@@ -155,19 +159,19 @@ timeGraphChartContainer.addLayers([timeGraphChartGridLayer, timeGraphChart,
 
 timeGraphChart.registerMouseInteractions({
     click: el => {
-        console.log('click: ' + el.constructor.name + ' : ' + JSON.stringify(el.model));
+        console.log('click: ' + el.constructor.name, el.model);
     },
     mouseover: el => {
-        console.log('mouseover: ' + el.constructor.name + ' : ' + JSON.stringify(el.model));
+        console.log('mouseover: ' + el.constructor.name, el.model);
     },
     mouseout: el => {
-        console.log('mouseout: ' + el.constructor.name + ' : ' + JSON.stringify(el.model));
+        console.log('mouseout: ' + el.constructor.name, el.model);
     },
     mousedown: el => {
-        console.log('mousedown: ' + el.constructor.name + ' : ' + JSON.stringify(el.model));
+        console.log('mousedown: ' + el.constructor.name, el.model);
     },
     mouseup: el => {
-        console.log('mouseup: ' + el.constructor.name + ' : ' + JSON.stringify(el.model));
+        console.log('mouseup: ' + el.constructor.name, el.model);
     }
 });
 

--- a/example/src/test-arrows.ts
+++ b/example/src/test-arrows.ts
@@ -5,16 +5,16 @@ export const timeGraphArrows: TimelineChart.TimeGraphArrow[] = [
         sourceId: 1,
         destinationId: 2,
         range:{
-            start: 1332170682486039800,
-            end: 1332170682489988000
+            start: BigInt('1332170682486039800'),
+            end: BigInt('1332170682489988000')
         }
     },
     {
         sourceId: 2,
         destinationId: 1,
         range:{
-            start: 1332170682497734100,
-            end: 1332170682497814000
+            start: BigInt('1332170682497734100'),
+            end: BigInt('1332170682497814000')
         }
     }
 ]

--- a/example/src/test-data-provider.ts
+++ b/example/src/test-data-provider.ts
@@ -150,8 +150,8 @@ export namespace TestData {
 }
 
 export class TestDataProvider {
-    protected absoluteStart: number;
-    protected totalLength: number;
+    protected absoluteStart: bigint;
+    protected totalLength: bigint;
     protected timeGraphEntries: object[];
     protected timeGraphRows: object[];
     protected canvasDisplayWidth: number;
@@ -159,21 +159,21 @@ export class TestDataProvider {
     constructor(canvasDisplayWidth: number) {
         this.timeGraphEntries = timeGraphEntries.model.entries;
         this.timeGraphRows = timeGraphStates.model.rows;
-        this.totalLength = 0;
+        this.totalLength = BigInt(0);
 
         this.canvasDisplayWidth = canvasDisplayWidth;
 
         this.timeGraphEntries.forEach((entry: TestData.TimeGraphEntry, rowIndex: number) => {
             const row = timeGraphStates.model.rows.find(row => row.entryID === entry.id);
             if (!this.absoluteStart) {
-                this.absoluteStart = entry.startTime;
-            } else if (entry.startTime < this.absoluteStart) {
-                this.absoluteStart = entry.startTime;
+                this.absoluteStart = BigInt(entry.startTime);
+            } else if (BigInt(entry.startTime) < this.absoluteStart) {
+                this.absoluteStart = BigInt(entry.startTime);
             }
             if (row) {
                 row.states.forEach((state: TestData.TimeGraphState, stateIndex: number) => {
                     if (state.value > 0) {
-                        const end = state.startTime + state.duration - entry.startTime;
+                        const end = BigInt(state.startTime + state.duration - entry.startTime);
                         this.totalLength = end > this.totalLength ? end : this.totalLength;
                     }
                 });
@@ -183,21 +183,21 @@ export class TestDataProvider {
 
     getData(opts: { range?: TimelineChart.TimeGraphRange, resolution?: number }): TimelineChart.TimeGraphModel {
         const rows: TimelineChart.TimeGraphRowModel[] = [];
-        const range = opts.range || { start: 0, end: this.totalLength };
-        const resolution = opts.resolution || this.totalLength / this.canvasDisplayWidth;
+        const range = opts.range || { start: BigInt(0), end: this.totalLength };
+        const resolution = opts.resolution || Number(this.totalLength) / this.canvasDisplayWidth;
         const commonRow = timeGraphStates.model.rows.find(row => row.entryId === -1);
         const _rangeEvents = commonRow?.annotations;
         const rangeEvents: TimelineChart.TimeGraphAnnotation[] = [];
-        const startTime = 1332170682440133097;
+        const startTime = BigInt(1332170682440133097);
         _rangeEvents?.forEach((annotation: any, annotationIndex: number) => {
-            const start = annotation.range.start - startTime;
+            const start = BigInt(annotation.range.start) - startTime;
             if (range.start < start && range.end > start) {
                 rangeEvents.push({
                     id: annotation.id,
                     category: annotation.category,
                     range: {
-                        start: annotation.range.start - this.absoluteStart,
-                        end: annotation.range.end - this.absoluteStart
+                        start: BigInt(annotation.range.start) - this.absoluteStart,
+                        end: BigInt(annotation.range.end) - this.absoluteStart
                     },
                     label: annotation.label,
                     data: annotation.data
@@ -210,14 +210,14 @@ export class TestDataProvider {
             const annotations: TimelineChart.TimeGraphAnnotation[] = [];
             const row = timeGraphStates.model.rows.find(row => row.entryID === entry.id);
             let hasStates = false;
-            let prevPossibleState = 0;
+            let prevPossibleState = BigInt(0);
             let nextPossibleState = this.totalLength;
             if (row) {
                 hasStates = !!row.states.length;
                 row.states.forEach((state: any, stateIndex: number) => {
                     if (state.value > 0 && state.duration * (1 / resolution) > 1) {
-                        const start = state.startTime - entry.startTime;
-                        const end = state.startTime + state.duration - entry.startTime;
+                        const start = BigInt(state.startTime - entry.startTime);
+                        const end = BigInt(state.startTime + state.duration - entry.startTime);
                         if (end > range.start && start < range.end) {
                             states.push({
                                 id: 'el_' + rowIndex + '_' + stateIndex,
@@ -228,24 +228,24 @@ export class TestDataProvider {
                         }
                     }
                     if (stateIndex === 0) {
-                        prevPossibleState = state.startTime - entry.startTime;
+                        prevPossibleState = BigInt(state.startTime - entry.startTime);
                     }
                     if (stateIndex === row.states.length - 1) {
-                        nextPossibleState = state.startTime + state.duration - entry.startTime;
+                        nextPossibleState = BigInt(state.startTime + state.duration - entry.startTime);
                     }
                 });
 
                 const _annotations = row.annotations;
                 if (!!_annotations) {
                     _annotations.forEach((annotation: any, annotationIndex: number) => {
-                        const start = annotation.range.start - entry.startTime;
+                        const start = BigInt(annotation.range.start - entry.startTime);
                         if (range.start < start && range.end > start) {
                             annotations.push({
                                 id: annotation.id,
                                 category: annotation.category,
                                 range: {
-                                    start: annotation.range.start - this.absoluteStart,
-                                    end: annotation.range.end - this.absoluteStart
+                                    start: BigInt(annotation.range.start) - this.absoluteStart,
+                                    end: BigInt(annotation.range.end) - this.absoluteStart
                                 },
                                 label: annotation.label,
                                 data: annotation.data
@@ -259,8 +259,8 @@ export class TestDataProvider {
                 id: entry.id,
                 name: entry.name[0],
                 range: {
-                    start: 0,
-                    end: entry.endTime - entry.startTime
+                    start: BigInt(0),
+                    end: BigInt(entry.endTime - entry.startTime)
                 },
                 states,
                 annotations,

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -16,7 +16,8 @@
         "allowJs": true,
         "lib": [
             "es6",
-            "dom"
+            "dom",
+            "esnext.bigint"
         ],
         "sourceMap": true,
         "outDir": "./lib"

--- a/timeline-chart/src/bigint-utils.ts
+++ b/timeline-chart/src/bigint-utils.ts
@@ -1,0 +1,33 @@
+export class BIMath {
+
+    static readonly round = (val: bigint | number): bigint => {
+        return typeof val === 'bigint' ? val : BigInt(Math.round(val));
+    };
+
+    static readonly clamp = (val: bigint | number, min: bigint, max: bigint): bigint => {
+        val = BIMath.round(val);
+        if (val < min) {
+            return min;
+        } else if (val > max) {
+            return max;
+        }
+        return val;
+    };
+
+    static readonly min = (val1: bigint | number, val2: bigint | number): bigint => {
+        val1 = BIMath.round(val1);
+        val2 = BIMath.round(val2);
+        return val1 <= val2 ? val1 : val2;
+    };
+
+    static readonly max = (val1: bigint | number, val2: bigint | number): bigint => {
+        val1 = BIMath.round(val1);
+        val2 = BIMath.round(val2);
+        return val1 >= val2 ? val1 : val2;
+    };
+
+    static readonly abs = (val: bigint | number): bigint => {
+        val = BIMath.round(val);
+        return val >= 0 ? val : -val;
+    };
+};

--- a/timeline-chart/src/components/time-graph-state.ts
+++ b/timeline-chart/src/components/time-graph-state.ts
@@ -23,7 +23,8 @@ export class TimeGraphStateComponent extends TimeGraphComponent<TimelineChart.Ti
     constructor(
         id: string,
         model: TimelineChart.TimeGraphState,
-        protected range: TimelineChart.TimeGraphRange,
+        xStart:  number,
+        xEnd: number,
         protected _row: TimeGraphRow,
         protected _style: TimeGraphStateStyle = { color: 0xfffa66, height: 14 },
         protected displayWidth: number,
@@ -33,11 +34,11 @@ export class TimeGraphStateComponent extends TimeGraphComponent<TimelineChart.Ti
         this._height = _style.height || 14;
         this._height = _row.height === 0 ? 0 : Math.min(this._height, _row.height - 1);
         this._position = {
-            x: this.range.start,
+            x: xStart,
             y: this._row.position.y + ((this.row.height - this._height) / 2)
         };
         // min width of a state should never be less than 1 (for visibility)
-        const width = Math.max(1, this.range.end - this.range.start);
+        const width = Math.max(1, xEnd - xStart);
         this._options = {
             color: _style.color,
             opacity: _style.opacity,

--- a/timeline-chart/src/layer/time-graph-axis-cursors.ts
+++ b/timeline-chart/src/layer/time-graph-axis-cursors.ts
@@ -25,8 +25,8 @@ export class TimeGraphAxisCursors extends TimeGraphLayer {
 
     update(): void {
         if (this.unitController.selectionRange) {
-            const firstCursorPosition = this.getPixels(this.unitController.selectionRange.start - this.unitController.viewRange.start);
-            const secondCursorPosition = this.getPixels(this.unitController.selectionRange.end - this.unitController.viewRange.start);
+            const firstCursorPosition = this.getPixel(this.unitController.selectionRange.start - this.unitController.viewRange.start);
+            const secondCursorPosition = this.getPixel(this.unitController.selectionRange.end - this.unitController.viewRange.start);
             const firstOpts = {
                 color: this.color,
                 position: {

--- a/timeline-chart/src/layer/time-graph-chart-arrows.ts
+++ b/timeline-chart/src/layer/time-graph-chart-arrows.ts
@@ -20,11 +20,11 @@ export class TimeGraphChartArrows extends TimeGraphChartLayer {
     protected getCoordinates(arrow: TimelineChart.TimeGraphArrow): TimeGraphArrowCoordinates {
         const relativeStartPosition = arrow.range.start - this.unitController.viewRange.start;
         const start: TimeGraphElementPosition = {
-            x: this.getPixels(relativeStartPosition),
+            x: this.getPixel(relativeStartPosition),
             y: (arrow.sourceId * this.rowController.rowHeight) + (this.rowController.rowHeight / 2)
         }
         const end: TimeGraphElementPosition = {
-            x: this.getPixels(relativeStartPosition + arrow.range.end - arrow.range.start),
+            x: this.getPixel(relativeStartPosition + arrow.range.end - arrow.range.start),
             y: (arrow.destinationId * this.rowController.rowHeight) + (this.rowController.rowHeight / 2)
         }
         return { start, end };

--- a/timeline-chart/src/layer/time-graph-chart-cursors.ts
+++ b/timeline-chart/src/layer/time-graph-chart-cursors.ts
@@ -6,6 +6,7 @@ import { TimelineChart } from "../time-graph-model";
 import { TimeGraphChartLayer } from "./time-graph-chart-layer";
 import { TimeGraphRowController } from "../time-graph-row-controller";
 import { TimeGraphChart } from "./time-graph-chart";
+import { BIMath } from "../bigint-utils";
 
 export class TimeGraphChartCursors extends TimeGraphChartLayer {
     protected mouseSelecting: boolean = false;
@@ -79,18 +80,18 @@ export class TimeGraphChartCursors extends TimeGraphChartLayer {
             this.mouseSelecting = true;
             this.stage.cursor = 'crosshair';
             const mouseX = event.data.global.x;
-            const xpos = this.unitController.viewRange.start + (mouseX / this.stateController.zoomFactor);
+            const end = this.unitController.viewRange.start + BIMath.round(mouseX / this.stateController.zoomFactor);
             this.chartLayer.selectState(undefined);
             if (extendSelection) {
-                const start = this.unitController.selectionRange ? this.unitController.selectionRange.start : 0;
+                const start = this.unitController.selectionRange ? this.unitController.selectionRange.start : BigInt(0);
                 this.unitController.selectionRange = {
                     start,
-                    end: xpos
+                    end
                 }
             } else {
                 this.unitController.selectionRange = {
-                    start: xpos,
-                    end: xpos
+                    start: end,
+                    end: end
                 }
             }
         };
@@ -108,11 +109,11 @@ export class TimeGraphChartCursors extends TimeGraphChartLayer {
                     return;
                 }
                 const mouseX = event.data.global.x;
-                const xStartPos = this.unitController.selectionRange.start;
-                const xEndPos = this.unitController.viewRange.start + (mouseX / this.stateController.zoomFactor);
+                const start = this.unitController.selectionRange.start;
+                const end = this.unitController.viewRange.start + BIMath.round(mouseX / this.stateController.zoomFactor);
                 this.unitController.selectionRange = {
-                    start: xStartPos,
-                    end: xEndPos
+                    start,
+                    end
                 }
             }
         }
@@ -235,21 +236,21 @@ export class TimeGraphChartCursors extends TimeGraphChartLayer {
     centerCursor() {
         if (this.unitController.selectionRange) {
             const cursorPosition = this.unitController.selectionRange.end;
-            const halfViewRangeLength = this.unitController.viewRangeLength / 2;
-            let startViewRange = cursorPosition - halfViewRangeLength;
-            let endViewRange = cursorPosition + halfViewRangeLength;
+            const halfViewRangeLength = this.unitController.viewRangeLength / BigInt(2);
+            let start = cursorPosition - halfViewRangeLength;
+            let end = cursorPosition + halfViewRangeLength;
 
-            if (startViewRange < 0) {
-                endViewRange -= startViewRange;
-                startViewRange = 0;
-            } else if (endViewRange > this.unitController.absoluteRange) {
-                startViewRange -= (endViewRange - this.unitController.absoluteRange);
-                endViewRange = this.unitController.absoluteRange;
+            if (start < 0) {
+                end -= start;
+                start = BigInt(0);
+            } else if (end > this.unitController.absoluteRange) {
+                start -= (end - this.unitController.absoluteRange);
+                end = this.unitController.absoluteRange;
             }
 
             this.unitController.viewRange = {
-                start: startViewRange,
-                end: endViewRange
+                start,
+                end
             }
         }
     }
@@ -260,8 +261,8 @@ export class TimeGraphChartCursors extends TimeGraphChartLayer {
 
     update() {
         if (this.unitController.selectionRange) {
-            const firstCursorPosition = this.getPixels(this.unitController.selectionRange.start - this.unitController.viewRange.start);
-            const secondCursorPosition = this.getPixels(this.unitController.selectionRange.end - this.unitController.viewRange.start);
+            const firstCursorPosition = this.getPixel(this.unitController.selectionRange.start - this.unitController.viewRange.start);
+            const secondCursorPosition = this.getPixel(this.unitController.selectionRange.end - this.unitController.viewRange.start);
             const firstCursorOptions = {
                 color: this.color,
                 height: this.stateController.canvasDisplayHeight,

--- a/timeline-chart/src/layer/time-graph-chart-selection-range.ts
+++ b/timeline-chart/src/layer/time-graph-chart-selection-range.ts
@@ -17,8 +17,8 @@ export class TimeGraphChartSelectionRange extends TimeGraphLayer {
 
     protected updateScaleAndPosition() {
         if (this.unitController.selectionRange && this.selectionRange) {
-            const firstCursorPosition = this.getPixels(this.unitController.selectionRange.start - this.unitController.viewRange.start);
-            const width = this.getPixels(this.unitController.selectionRange.end - this.unitController.selectionRange.start)
+            const firstCursorPosition = this.getPixel(this.unitController.selectionRange.start - this.unitController.viewRange.start);
+            const width = this.getPixel(this.unitController.selectionRange.end - this.unitController.selectionRange.start)
             this.selectionRange.update({
                 position: {
                     x: firstCursorPosition,
@@ -48,8 +48,8 @@ export class TimeGraphChartSelectionRange extends TimeGraphLayer {
 
     update() {
         if (this.unitController.selectionRange) {
-            const firstCursorPosition = this.getPixels(this.unitController.selectionRange.start - this.unitController.viewRange.start);
-            const secondCursorPosition = this.getPixels(this.unitController.selectionRange.end - this.unitController.viewRange.start);
+            const firstCursorPosition = this.getPixel(this.unitController.selectionRange.start - this.unitController.viewRange.start);
+            const secondCursorPosition = this.getPixel(this.unitController.selectionRange.end - this.unitController.viewRange.start);
             if (secondCursorPosition !== firstCursorPosition) {
                 if (!this.selectionRange) {
                     this.selectionRange = new TimeGraphRectangle({

--- a/timeline-chart/src/layer/time-graph-layer.ts
+++ b/timeline-chart/src/layer/time-graph-layer.ts
@@ -63,8 +63,11 @@ export abstract class TimeGraphLayer {
         idx && this.children.splice(idx, 1);
     }
 
-    protected getPixels(ticks: number) {
-        return ticks * this.stateController.zoomFactor;
+    protected getPixel(time: bigint) {
+        const div = 0x100000000;
+        const hi = Number(time / BigInt(div));
+        const lo = Number(time % BigInt(div));
+        return Math.floor(hi * this.stateController.zoomFactor * div + lo * this.stateController.zoomFactor);
     }
 
     protected afterAddToContainer() { }

--- a/timeline-chart/src/layer/time-graph-navigator.ts
+++ b/timeline-chart/src/layer/time-graph-navigator.ts
@@ -4,6 +4,7 @@ import { TimeGraphStateController } from "../time-graph-state-controller";
 import { TimeGraphRectangle } from "../components/time-graph-rectangle";
 import { TimeGraphLayer } from "./time-graph-layer";
 import { TimelineChart } from "../time-graph-model";
+import { BIMath } from "../bigint-utils";
 
 export class TimeGraphNavigator extends TimeGraphLayer {
 
@@ -30,10 +31,10 @@ export class TimeGraphNavigator extends TimeGraphLayer {
                 height: this.stateController.canvasDisplayHeight,
                 opacity: 0.5,
                 position: {
-                    x: this.unitController.selectionRange.start * this.stateController.absoluteResolution,
+                    x: Number(this.unitController.selectionRange.start) * this.stateController.absoluteResolution,
                     y: 0
                 },
-                width: (this.unitController.selectionRange.end - this.unitController.selectionRange.start) * this.stateController.absoluteResolution
+                width: Number(this.unitController.selectionRange.end - this.unitController.selectionRange.start) * this.stateController.absoluteResolution
             };
             if (!this.selectionRange) {
                 this.selectionRange = new TimeGraphRectangle(selectionOpts);
@@ -61,7 +62,7 @@ export class TimeGraphNavigatorHandle extends TimeGraphComponent<null> {
 
     protected mouseIsDown: boolean;
     protected mouseStartX: number;
-    protected oldViewStart: number;
+    protected oldViewStart: bigint;
 
     constructor(protected unitController: TimeGraphUnitController, protected stateController: TimeGraphStateController) {
         super('navigator_handle');
@@ -73,9 +74,9 @@ export class TimeGraphNavigatorHandle extends TimeGraphComponent<null> {
         this.addEvent('mousemove', event => {
             if (this.mouseIsDown) {
                 const delta = event.data.global.x - this.mouseStartX;
-                var start = Math.max(this.oldViewStart + (delta / this.stateController.absoluteResolution), 0);
-                start = Math.min(start, this.unitController.absoluteRange - this.unitController.viewRangeLength);
-                const end = Math.min(start + this.unitController.viewRangeLength, this.unitController.absoluteRange)
+                const start = BIMath.clamp(Number(this.oldViewStart) + (delta / this.stateController.absoluteResolution),
+                    BigInt(0), this.unitController.absoluteRange - this.unitController.viewRangeLength);
+                const end = start + this.unitController.viewRangeLength;
                 this.unitController.viewRange = {
                     start,
                     end
@@ -91,11 +92,11 @@ export class TimeGraphNavigatorHandle extends TimeGraphComponent<null> {
 
     render(): void {
         const MIN_NAVIGATOR_WIDTH = 20;
-        const xPos = this.unitController.viewRange.start * this.stateController.absoluteResolution;
-        const effectiveAbsoluteRange = this.unitController.absoluteRange * this.stateController.absoluteResolution;
+        const xPos = Number(this.unitController.viewRange.start) * this.stateController.absoluteResolution;
+        const effectiveAbsoluteRange = Number(this.unitController.absoluteRange) * this.stateController.absoluteResolution;
         // Avoid the navigator rendered outside of the range at high zoom levels when its width is capped to MIN_NAVIGATOR_WIDTH
         const position = { x: Math.min(effectiveAbsoluteRange - MIN_NAVIGATOR_WIDTH, xPos), y: 0 };
-        const width = Math.max(MIN_NAVIGATOR_WIDTH, this.unitController.viewRangeLength * this.stateController.absoluteResolution);
+        const width = Math.max(MIN_NAVIGATOR_WIDTH, Number(this.unitController.viewRangeLength) * this.stateController.absoluteResolution);
         this.rect({
             height: 20,
             position,

--- a/timeline-chart/src/layer/time-graph-range-events-layer.ts
+++ b/timeline-chart/src/layer/time-graph-range-events-layer.ts
@@ -21,8 +21,8 @@ export class TimeGraphRangeEventsLayer extends TimeGraphLayer {
     }
 
     protected addRangeEvent(rangeEvent: TimelineChart.TimeGraphAnnotation) {
-        const start = this.getPixels(rangeEvent.range.start - this.unitController.viewRange.start);
-        const end = this.getPixels(rangeEvent.range.end - this.unitController.viewRange.start);
+        const start = this.getPixel(rangeEvent.range.start - this.unitController.viewRange.start);
+        const end = this.getPixel(rangeEvent.range.end - this.unitController.viewRange.start);
         const width = end - start;
         const elementStyle = this.providers.rowAnnotationStyleProvider ? this.providers.rowAnnotationStyleProvider(rangeEvent) : undefined;
         const rangeEventComponent = new TimeGraphRectangle({
@@ -62,8 +62,8 @@ export class TimeGraphRangeEventsLayer extends TimeGraphLayer {
 
     protected updateRangeEvent(rangeEvent: TimelineChart.TimeGraphAnnotation) {
         const rangeEventComponent = this.rangeEvents.get(rangeEvent);
-        const start = this.getPixels(rangeEvent.range.start - this.unitController.viewRange.start);
-        const end = this.getPixels(rangeEvent.range.end - this.unitController.viewRange.start);
+        const start = this.getPixel(rangeEvent.range.start - this.unitController.viewRange.start);
+        const end = this.getPixel(rangeEvent.range.end - this.unitController.viewRange.start);
         const width = end - start;
         if (rangeEventComponent) {
             rangeEventComponent.update({

--- a/timeline-chart/src/time-graph-model.ts
+++ b/timeline-chart/src/time-graph-model.ts
@@ -1,12 +1,12 @@
 export namespace TimelineChart {
     export interface TimeGraphRange {
-        start: number
-        end: number
+        start: bigint
+        end: bigint
     }
 
     export interface TimeGraphModel {
         id: string
-        totalLength: number
+        totalLength: bigint
         rows: TimeGraphRowModel[]
         rangeEvents: TimeGraphAnnotation[]
         arrows: TimeGraphArrow[]
@@ -21,8 +21,8 @@ export namespace TimelineChart {
         annotations: TimeGraphAnnotation[]
         selected?: boolean
         readonly data?: { [key: string]: any }
-        prevPossibleState: number
-        nextPossibleState: number
+        prevPossibleState: bigint
+        nextPossibleState: bigint
     }
 
     export interface TimeGraphState {

--- a/timeline-chart/src/time-graph-state-controller.ts
+++ b/timeline-chart/src/time-graph-state-controller.ts
@@ -81,12 +81,12 @@ export class TimeGraphStateController {
     }
 
     get zoomFactor(): number {
-        this._zoomFactor = this.canvasDisplayWidth / this.unitController.viewRangeLength;
+        this._zoomFactor = this.canvasDisplayWidth / Number(this.unitController.viewRangeLength);
         return this._zoomFactor;
     }
 
     get absoluteResolution(): number {
-        return this.canvasDisplayWidth / this.unitController.absoluteRange;
+        return this.canvasDisplayWidth / Number(this.unitController.absoluteRange);
     }
 
     get positionOffset(): {

--- a/timeline-chart/src/time-graph-unit-controller.ts
+++ b/timeline-chart/src/time-graph-unit-controller.ts
@@ -11,12 +11,12 @@ export class TimeGraphUnitController {
      *  Create a string from the given number, which is shown in TimeAxis.
      *  Or return undefined to not show any text for that number.
      */
-    numberTranslator?: (theNumber: number) => string | undefined;
+    numberTranslator?: (theNumber: bigint) => string | undefined;
     scaleSteps?: number[]
 
-    constructor(public absoluteRange: number, viewRange?: TimelineChart.TimeGraphRange) {
+    constructor(public absoluteRange: bigint, viewRange?: TimelineChart.TimeGraphRange) {
         this.viewRangeChangedHandlers = [];
-        this._viewRange = viewRange || { start: 0, end: absoluteRange };
+        this._viewRange = viewRange || { start: BigInt(0), end: absoluteRange };
 
         this.selectionRangeChangedHandlers = [];
     }
@@ -59,7 +59,7 @@ export class TimeGraphUnitController {
             this._viewRange = { start: newRange.start, end: newRange.end };
         }
         if (newRange.start < 0) {
-            this._viewRange.start = 0;
+            this._viewRange.start = BigInt(0);
         }
         if (this._viewRange.end > this.absoluteRange) {
             this._viewRange.end = this.absoluteRange;
@@ -75,7 +75,7 @@ export class TimeGraphUnitController {
         this.handleSelectionRangeChange();
     }
 
-    get viewRangeLength(): number {
+    get viewRangeLength(): bigint {
         return this._viewRange.end - this._viewRange.start;
     }
 }

--- a/timeline-chart/tsconfig.json
+++ b/timeline-chart/tsconfig.json
@@ -15,7 +15,8 @@
         "jsx": "react",
         "lib": [
             "es6",
-            "dom"
+            "dom",
+            "esnext.bigint"
         ],
         "declaration": true,
         "sourceMap": true,


### PR DESCRIPTION
Timestamps and time durations are changed to be of type 'bigint' instead
of 'number'.

This is done to avoid loss of precision in JavaScript 'number' type for
values above Number.MAX_SAFE_INTEGER (2^53 - 1).

The class BIMath is added to provide some BigInt math utility functions.

The method TimeGraphLayer.getPixels() is renamed to getPixel() since it
returns only one value.

In the time graph axis, fractional scale steps 1.5 and 2.5 are removed
to avoid non-equidistant ticks when zoomed in to nanosecond level, due
to BigInt integer rounding.

The minimum view range is set to 2 ns, to be able to zoom out of it and
to always have at least one time graph axis tick fully visible.

Signed-off-by: Patrick Tasse <patrick.tasse@ericsson.com>