### PR TITLE
Removed cached height and position in time graph state component

### DIFF
--- a/timeline-chart/src/components/time-graph-state.ts
+++ b/timeline-chart/src/components/time-graph-state.ts
@@ -14,8 +14,6 @@ export interface TimeGraphStateStyle {
 
 export class TimeGraphStateComponent extends TimeGraphComponent<TimelineChart.TimeGraphState> {
 
-    protected _height: number;
-    protected _position: TimeGraphElementPosition;
     static fontController: FontController = new FontController();
 
     protected _options: TimeGraphStyledRect;
@@ -31,19 +29,18 @@ export class TimeGraphStateComponent extends TimeGraphComponent<TimelineChart.Ti
         displayObject?: PIXI.Graphics
     ) {
         super(id, displayObject, model);
-        this._height = _style.height || 14;
-        this._height = _row.height === 0 ? 0 : Math.min(this._height, _row.height - 1);
-        this._position = {
+        const height = _row.height === 0 ? 0 : Math.min(_style.height || 14, _row.height - 1);
+        const position = {
             x: xStart,
-            y: this._row.position.y + ((this.row.height - this._height) / 2)
+            y: this._row.position.y + ((this.row.height - height) / 2)
         };
         // min width of a state should never be less than 1 (for visibility)
         const width = Math.max(1, xEnd - xStart);
         this._options = {
             color: _style.color,
             opacity: _style.opacity,
-            height: this._height,
-            position: this._position,
+            height,
+            position,
             width,
             displayWidth,
             borderRadius: 2,
@@ -109,11 +106,15 @@ export class TimeGraphStateComponent extends TimeGraphComponent<TimelineChart.Ti
     }
 
     get height(): number {
-        return this._height;
+        return this._options.height;
+    }
+
+    get width(): number {
+        return this._options.width;
     }
 
     get position(): TimeGraphElementPosition {
-        return this._position;
+        return this._options.position;
     }
 
     get row(): TimeGraphRow {


### PR DESCRIPTION
The height and position of a state is not fixed, it can be updated when
the view range is changed.

The time graph state component stores these both as field variables and
as part of the state options object. Only the variables in the options
are updated, the field variables remain to what was set at construction,
so the getters return obsolete values.

Remove the field variables and update the getters to return the latest
values from the options object.

Add a getter for the width.

Change-Id: I1987c2c2630d46eb27e64ca879e97fd942090824
Signed-off-by: Patrick Tasse <patrick.tasse@ericsson.com>