### PR TITLE
Make time graph state label optional

### DIFF
--- a/timeline-chart/src/time-graph-model.ts
+++ b/timeline-chart/src/time-graph-model.ts
@@ -28,7 +28,7 @@ export namespace TimelineChart {
     export interface TimeGraphState {
         readonly id: string
         readonly range: TimeGraphRange
-        readonly label: string
+        readonly label?: string
         selected?: boolean
         readonly data?: { [key: string]: any }
     }


### PR DESCRIPTION
Not all time graph states have a label. Make the variable optional
instead of requiring users to put an empty string.

Change-Id: I980917cfb0d6c761e78905bc5bfef5ee3480da86
Signed-off-by: Patrick Tasse <patrick.tasse@ericsson.com>