### PR TITLE
Create gap states dynamically

### DIFF
--- a/timeline-chart/src/time-graph-model.ts
+++ b/timeline-chart/src/time-graph-model.ts
@@ -23,6 +23,13 @@ export namespace TimelineChart {
         readonly data?: { [key: string]: any }
         prevPossibleState: bigint
         nextPossibleState: bigint
+        /**
+         * When the gap style is set, gap states will be drawn using this style
+         * in between the model's states when the gap between these states is visible.
+         * These gap states represent the unknown state between known states.
+         * Known blank states (with no style) must then be included in the model.
+         */
+        gapStyle?: any;
     }
 
     export interface TimeGraphState {


### PR DESCRIPTION
When a row has a gap style, dynamically create a gap state with this
style whenever two contiguous states in the row do not touch at the
pixel level.

A gap state is also created before any null state, even if the previous
state ended at the same pixel. This is to ensure that a short gap
between two long null states is visible.

Add, update or remove gap states as necessary when the view range is
updated for the same time graph model.

This requires that the time graph model received from the user includes
any null states (states without any style) so that gap states can be
created in the gap between such states.

Change-Id: Ib61bc78ef6d6755dacbe196d21a7210e6e4af269
Signed-off-by: Patrick Tasse <patrick.tasse@ericsson.com>