### PR TITLE
Fix RangeError when zooming with zero view range

### DIFF
--- a/timeline-chart/src/layer/time-graph-chart.ts
+++ b/timeline-chart/src/layer/time-graph-chart.ts
@@ -81,6 +81,9 @@ export class TimeGraphChart extends TimeGraphChartLayer {
     }
 
     adjustZoom(zoomPosition: number | undefined, hasZoomedIn: boolean) {
+        if (this.unitController.viewRangeLength <= 0) {
+            return;
+        }
         if (zoomPosition === undefined) {
             const start = this.getPixel(this.unitController.selectionRange ? this.unitController.selectionRange.start - this.unitController.viewRange.start : BigInt(0));
             const end = this.getPixel(this.unitController.selectionRange ? this.unitController.selectionRange.end - this.unitController.viewRange.start : this.unitController.viewRangeLength);


### PR DESCRIPTION
When the view range is zero, the zooming mouse and keyboard handlers
cause a RangeError due to a division by zero. Abort the zooming early
instead.

Change-Id: Ib2301261cbbf9acce3be8763d71350d72e608294
Signed-off-by: Patrick Tasse <patrick.tasse@ericsson.com>