### PR TITLE
Fix TimeGraphRangeEventsLayer leaking viewRangeChanged handler

### DIFF
--- a/timeline-chart/src/layer/time-graph-range-events-layer.ts
+++ b/timeline-chart/src/layer/time-graph-range-events-layer.ts
@@ -8,7 +8,6 @@ export class TimeGraphRangeEventsLayer extends TimeGraphLayer {
     protected providers: TimeGraphChartProviders;
 
     private _viewRangeUpdateHandler: { (): void; (viewRange: TimelineChart.TimeGraphRange): void; (viewRange: TimelineChart.TimeGraphRange): void; };
-    private _updateHandler: { (): void; (selectionRange: TimelineChart.TimeGraphRange): void; (selectionRange: TimelineChart.TimeGraphRange): void; };
 
     constructor(id: string, providers: TimeGraphChartProviders) {
         super(id);
@@ -16,8 +15,8 @@ export class TimeGraphRangeEventsLayer extends TimeGraphLayer {
     }
 
     protected afterAddToContainer() {
-        this._updateHandler = (): void => this.update();
-        this.unitController.onViewRangeChanged(this._updateHandler);
+        this._viewRangeUpdateHandler = (): void => this.update();
+        this.unitController.onViewRangeChanged(this._viewRangeUpdateHandler);
     }
 
     protected addRangeEvent(rangeEvent: TimelineChart.TimeGraphAnnotation) {
@@ -80,7 +79,6 @@ export class TimeGraphRangeEventsLayer extends TimeGraphLayer {
     destroy(): void {
         if (this.unitController) {
             this.unitController.removeViewRangeChangedHandler(this._viewRangeUpdateHandler);
-            this.unitController.removeSelectionRangeChangedHandler(this._updateHandler);
         }
         super.destroy();
     }


### PR DESCRIPTION
The wrong handler was being removed and the leaking handler would cause
exceptions when it got called subsequently.

Change-Id: Ic6386a4478e49f92b57ed75e2f5090a0f31c1b2a
Signed-off-by: Patrick Tasse <patrick.tasse@ericsson.com>