### PR TITLE
Update data model on resize

### DIFF
--- a/timeline-chart/src/layer/time-graph-chart.ts
+++ b/timeline-chart/src/layer/time-graph-chart.ts
@@ -70,6 +70,8 @@ export class TimeGraphChart extends TimeGraphChartLayer {
     private _mouseWheelHandler: { (ev: WheelEvent): void; (event: Event): void; (event: Event): void; };
     private _contextMenuHandler: { (e: MouseEvent): void; (event: Event): void; };
 
+    private _debouncedMaybeFetchNewData = debounce(() => this.maybeFetchNewData(), 400);
+
     // Keep track of the most recently clicked point.
     // If clicked again during _multiClickTime duration (milliseconds) record multi-click
     private _recentlyClickedGlobal: PIXI.Point | null = null;
@@ -333,7 +335,7 @@ export class TimeGraphChart extends TimeGraphChartLayer {
             }
         };
         this.unitController.onViewRangeChanged(this._viewRangeChangedHandler);
-        this.unitController.onViewRangeChanged(debounce(() => this.maybeFetchNewData(), 400));
+        this.unitController.onViewRangeChanged(this._debouncedMaybeFetchNewData);
 
         if (this.unitController.viewRangeLength && this.stateController.canvasDisplayWidth) {
             this.maybeFetchNewData();
@@ -349,6 +351,7 @@ export class TimeGraphChart extends TimeGraphChartLayer {
 
     update() {
         this.updateScaleAndPosition();
+        this._debouncedMaybeFetchNewData();
     }
 
     updateZoomingSelection() {
@@ -410,7 +413,7 @@ export class TimeGraphChart extends TimeGraphChartLayer {
         if (viewRange && (
             viewRange.start < this.providedRange.start ||
             viewRange.end > this.providedRange.end ||
-            resolution < this.providedResolution ||
+            resolution != this.providedResolution ||
             update
         )) {
             try {


### PR DESCRIPTION
When the time graph canvas width is increased by a resize event, the
data model may no longer be at the appropriate resolution. Invoke the
debounced method to maybe fetch new data, in the same way as is done
when the view range is changed.

Update the data model when the resolution is changed either way (not
only when zooming in) so that an appropriately sized and consistent data
model is always used.

Change-Id: I33373a3fa490ae94e157e20638423de149c91021
Signed-off-by: Patrick Tasse <patrick.tasse@ericsson.com>